### PR TITLE
Parse xml string from RAM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: rust
 rust: nightly
+addons:
+    apt:
+        packages: libxml2-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,11 +2,40 @@
 name = "rustlibxml"
 version = "0.0.1"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "advapi32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gcc"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.1.8"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ build = "build.rs"
 [dependencies]
 libc = "~0.1"
 
+[build-dependencies]
+gcc = "0.3.21"
+
 [lib]
 name = "rustlibxml"
 

--- a/build.rs
+++ b/build.rs
@@ -4,20 +4,12 @@
 //! header files are in `/usr/include/libxml2`.
 //! In the future, we should move to a more flexible solution.
 
+extern crate gcc;
 
 fn main() {
-    let out_dir = std::env::var("OUT_DIR").unwrap();
-    let out_path = |f : &str| format!("{}/{}", out_dir, f);
-    std::process::Command::new("gcc")
-        .args(&["src/helper_functions.c", "-I/usr/include/libxml2", 
-                "-lxml", "-c", "-fPIC", "-o",
-                &out_path("helper_functions.o")])
-        .status().unwrap();
-    std::process::Command::new("ar")
-        .args(&["-crs", &out_path("/libhelper_functions.a"),
-                &out_path("/helper_functions.o")])
-        .status().unwrap();
-    println!("cargo:rustc-link-search=native={}", out_dir);
-    println!("cargo:rustc-link-lib=static=helper_functions");
+    gcc::Config::new()
+        .file("src/helper_functions.c")
+        .include("/usr/include/libxml2")
+        .compile("libhelper_functions.a");
 }
 

--- a/src/c_signatures.rs
+++ b/src/c_signatures.rs
@@ -21,6 +21,7 @@ extern "C" {
 
     //parser
     pub fn xmlParseFile(filename: *const c_char) -> *mut c_void;
+    pub fn xmlParseDoc(xml_string: *const c_char) -> *mut c_void;
     // pub fn htmlParseFile(filename: *const c_char, encoding: *const c_char) -> *mut c_void;
     pub fn htmlReadFile(filename: *const c_char, encoding: *const c_char, options: c_uint) -> *mut c_void;
     pub fn xmlCleanupParser();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -49,6 +49,19 @@ impl XmlDoc {
         }
     }
 
+    ///Parses the XML string (0-terminated) contained in 'xml_string' to generate a new 'XmlDoc'
+    pub fn parse_xml_string(xml_string: &str) -> Result<XmlDoc, XmlParseError> {
+        let c_string = CString::new(xml_string).unwrap().as_ptr();
+        unsafe {
+            let docptr = xmlParseDoc(c_string);
+            if docptr.is_null() {
+                return Err(XmlParseError::GotNullPointer);
+            }
+
+            Ok(XmlDoc {doc_ptr: docptr})
+        }
+    }
+
     ///Parses the HTML file `filename` to generate a new `XmlDoc`
     pub fn parse_html_file(filename : &str) -> Result<XmlDoc, XmlParseError> {
         let c_filename = CString::new(filename).unwrap().as_ptr();

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -10,7 +10,6 @@ use std::collections::HashSet;
 
 
 ///An xml node
-#[allow(raw_pointer_derive)]
 #[derive(Clone)]
 pub struct XmlNodeRef {
     ///libxml's xmlNodePtr

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -6,7 +6,6 @@ use tree::{XmlDoc, XmlNodeRef};
 use std::ffi::{CString};
 
 ///The xpath context
-#[allow(raw_pointer_derive)]
 #[derive(Clone)]
 pub struct XmlXPathContext {
     ///libxml's `xmlXPathContextPtr`
@@ -24,7 +23,6 @@ impl Drop for XmlXPathContext {
 }
 
 ///Essentially, the result of the evaluation of some xpath expression
-#[allow(raw_pointer_derive)]
 #[derive(Clone)]
 pub struct XmlXPathObject {
     ///libxml's `xmlXpathObjectPtr`

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,10 +2,9 @@
 //! Knowing how much I neglect this aspect of software development,
 //! there probably won't be a significant coverage.
 
-#![feature(hash)]
 extern crate rustlibxml;
 
-use rustlibxml::tree::{XmlDoc, XmlNodeRef};
+use rustlibxml::tree::XmlDoc;
 use rustlibxml::xpath::{XmlXPathContext};
 use rustlibxml::parser::xml_cleanup_parser;
 use std::hash::{Hash, Hasher, SipHasher};


### PR DESCRIPTION
Added support for parsing of an XML string from a Rust str (previously only bindings were provided to parse from a file). 
Also fixed the tests (hopefully in a correct way :smile:), cleaned up some warnings, probably a remainder from older Rust versions..

P.S. some tests seem to fail sometimes, may be worth looking into? (even if you hate writing them ;))
