### PR TITLE
Compat for Rust nightly 22.02: hold CString::new results in var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,40 +2,17 @@
 name = "libxml"
 version = "0.0.2"
 dependencies = [
- "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "advapi32-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "gcc"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "libc"
 version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -70,15 +70,15 @@ impl Parser {
   }
   ///Parses the XML/HTML file `filename` to generate a new `Document`
   pub fn parse_file(&self, filename : &str) -> Result<Document, XmlParseError> {
-    let c_filename = CString::new(filename).unwrap().as_ptr();
-    let c_utf8 = CString::new("utf-8").unwrap().as_ptr();
+    let c_filename = CString::new(filename).unwrap();
+    let c_utf8 = CString::new("utf-8").unwrap();
     let options : u32 = XmlParserOption::XmlParseRecover as u32 +
                         XmlParserOption::XmlParseNoerror as u32 +
                         XmlParserOption::XmlParseNowarning as u32;
     match self.format {
       ParseFormat::XML => { unsafe {
         xmlKeepBlanksDefault(1);
-        let docptr = xmlReadFile(c_filename, c_utf8, options);
+        let docptr = xmlReadFile(c_filename.as_ptr(), c_utf8.as_ptr(), options);
         match docptr.is_null() {
           true => Err(XmlParseError::GotNullPointer),
           false => Ok(Document::new_ptr(docptr))
@@ -91,7 +91,7 @@ impl Parser {
                               HtmlParserOption::HtmlParseNoerror as u32 +
                               HtmlParserOption::HtmlParseNowarning as u32;
           xmlKeepBlanksDefault(1);
-          let docptr = htmlReadFile(c_filename, c_utf8, options);
+          let docptr = htmlReadFile(c_filename.as_ptr(), c_utf8.as_ptr(), options);
           match docptr.is_null() {
             true => Err(XmlParseError::GotNullPointer),
             false => Ok(Document::new_ptr(docptr))
@@ -103,17 +103,17 @@ impl Parser {
 
   ///Parses the XML/HTML string `input_string` to generate a new `Document`
   pub fn parse_string(&self, input_string: &str) -> Result<Document, XmlParseError> {
-    let c_string = CString::new(input_string).unwrap().as_ptr();
-    let c_utf8 = CString::new("utf-8").unwrap().as_ptr();
+    let c_string = CString::new(input_string).unwrap();
+    let c_utf8 = CString::new("utf-8").unwrap();
     match self.format {
       ParseFormat::XML => { unsafe {
-        let docptr = xmlParseDoc(c_string);
+        let docptr = xmlParseDoc(c_string.as_ptr());
         match docptr.is_null() {
           true => Err(XmlParseError::GotNullPointer),
           false => Ok(Document::new_ptr(docptr))
         } } },
       ParseFormat::HTML => { unsafe {
-        let docptr = htmlParseDoc(c_string, c_utf8);
+        let docptr = htmlParseDoc(c_string.as_ptr(), c_utf8.as_ptr());
         match docptr.is_null() {
           true => Err(XmlParseError::GotNullPointer),
           false => Ok(Document::new_ptr(docptr))
@@ -130,22 +130,22 @@ impl Parser {
     if input_string.is_empty() {
       return false
     }
-    let c_string = CString::new(input_string).unwrap().as_ptr();
-    let c_utf8 = CString::new("utf-8").unwrap().as_ptr();
+    let c_string = CString::new(input_string).unwrap();
+    let c_utf8 = CString::new("utf-8").unwrap();
     // disable generic error lines from libxml2
     match self.format {
       ParseFormat::XML => false, // TODO: Add support for XML at some point
       ParseFormat::HTML => unsafe {
         let ctxt = htmlNewParserCtxt();
         setWellFormednessHandler(ctxt);
-        let docptr = htmlCtxtReadDoc(ctxt, c_string, ptr::null_mut(), c_utf8, 10596); // htmlParserOption = 4+32+64+256+2048+8192
+        let docptr = htmlCtxtReadDoc(ctxt, c_string.as_ptr(), ptr::null_mut(), c_utf8.as_ptr(), 10596); // htmlParserOption = 4+32+64+256+2048+8192
         let is_well_formed = htmlWellFormed(ctxt);
-        let well_formed_final = if is_well_formed > 0 { 
+        let well_formed_final = if is_well_formed > 0 {
           // Basic well-formedness passes, let's check if we have an <html> element as root too
           if !docptr.is_null() {
             let node_ptr = xmlDocGetRootElement(docptr);
             let name_ptr = xmlNodeGetName(node_ptr);
-            if name_ptr.is_null() { 
+            if name_ptr.is_null() {
               false }  //empty string
             else {
               let c_root_name = CStr::from_ptr(name_ptr);

--- a/src/xpath.rs
+++ b/src/xpath.rs
@@ -43,8 +43,8 @@ impl Context {
     }
     ///evaluate an xpath
     pub fn evaluate(&self, xpath: &str) -> Result<Object, ()> {
-        let c_xpath = CString::new(xpath).unwrap().as_ptr();
-        let result = unsafe { xmlXPathEvalExpression(c_xpath, self.context_ptr) };
+        let c_xpath = CString::new(xpath).unwrap();
+        let result = unsafe { xmlXPathEvalExpression(c_xpath.as_ptr(), self.context_ptr) };
         if result.is_null() {
             Err(())
         } else {
@@ -89,7 +89,7 @@ impl Object {
             if ptr.is_null() {
                 panic!("rust-libxml: xpath: found null pointer result set");
             }
-            vec.push(Node { node_ptr : ptr, });//node_is_inserted : true 
+            vec.push(Node { node_ptr : ptr, });//node_is_inserted : true
         }
         vec
     }

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -17,7 +17,7 @@ fn hello_builder() {
   let doc_result = Document::new();
   assert!(doc_result.is_ok());
   let mut doc = doc_result.unwrap();
-  
+
   let hello_element_result = Node::new("hello", None, &doc);
   assert!(hello_element_result.is_ok());
   let mut hello_element = hello_element_result.unwrap();
@@ -63,10 +63,10 @@ fn create_pi() {
 fn duplicate_file() {
     let parser = Parser::default();
     {
-      let doc_parse = parser.parse_file("tests/resources/file01.xml");
-      assert!(doc_parse.is_ok());
-      
-      let doc = doc_parse.unwrap();
+      let doc_result = parser.parse_file("tests/resources/file01.xml");
+      assert!(doc_result.is_ok());
+
+      let doc = doc_result.unwrap();
       doc.save_file("tests/results/copy.xml").unwrap();
     }
 }
@@ -87,10 +87,10 @@ fn can_parse_xml_string() {
 fn can_load_html_file() {
   let parser = Parser::default_html();
   {
-    let doc_parse = parser.parse_file("tests/resources/example.html");
-    assert!(doc_parse.is_ok());
+    let doc_result = parser.parse_file("tests/resources/example.html");
+    assert!(doc_result.is_ok());
 
-    let doc = doc_parse.unwrap();
+    let doc = doc_result.unwrap();
     let root_result = doc.get_root_element();
     assert!(root_result.is_ok());
     let root = root_result.unwrap();
@@ -104,7 +104,9 @@ fn can_load_html_file() {
 fn child_of_root_has_different_hash() {
   let parser = Parser::default();
   {
-    let doc = parser.parse_file("tests/resources/file01.xml").unwrap();
+    let doc_result = parser.parse_file("tests/resources/file01.xml");
+    assert!(doc_result.is_ok());
+    let doc = doc_result.unwrap();
     let root = doc.get_root_element().unwrap();
     assert!(!root.is_text_node());
     if let Some(child) = root.get_first_child() {
@@ -123,7 +125,7 @@ fn sibling_unit_tests() {
   assert!(hello_element_result.is_ok());
   let mut hello_element = hello_element_result.unwrap();
   doc.set_root_element(&mut hello_element);
-  
+
   let new_sibling = Node::new("sibling", None, &doc).unwrap();
   assert!(hello_element.add_prev_sibling(new_sibling).is_some());
 }
@@ -132,7 +134,9 @@ fn sibling_unit_tests() {
 /// Test the evaluation of an xpath expression yields the correct number of nodes
 fn test_xpath_result_number_correct() {
   let parser = Parser::default();
-  let doc = parser.parse_file("tests/resources/file01.xml").unwrap();
+  let doc_result = parser.parse_file("tests/resources/file01.xml");
+  assert!(doc_result.is_ok());
+  let doc = doc_result.unwrap();
   let context = Context::new(&doc).unwrap();
 
   let result1 = context.evaluate("//child").unwrap();
@@ -150,13 +154,17 @@ fn test_xpath_result_number_correct() {
 /// that the class names are interpreted correctly.
 fn test_class_names() {
   let parser = Parser::default_html();
-  let doc = parser.parse_file("tests/resources/file02.xml").unwrap();
+  let doc_result = parser.parse_file("tests/resources/file02.xml");
+  assert!(doc_result.is_ok());
+  let doc = doc_result.unwrap();
   let context = Context::new(&doc).unwrap();
-  
-  let result = context.evaluate("/html/body/p").unwrap();
-  assert_eq!(result.get_number_of_nodes(), 1);
-  
-  let node = &result.get_nodes_as_vec()[0];
+
+  let p_result = context.evaluate("/html/body/p");
+  assert!(p_result.is_ok());
+  let p = p_result.unwrap();
+  assert_eq!(p.get_number_of_nodes(), 1);
+
+  let node = &p.get_nodes_as_vec()[0];
   let names = node.get_class_names();
   assert_eq!(names.len(), 2);
   assert!(names.contains("paragraph"));
@@ -169,7 +177,7 @@ fn test_class_names() {
 /// IMPORTANT: Currenlty NOT THREAD-SAFE, use in single-threaded apps only!
 fn test_well_formed_html() {
   let parser = Parser::default_html();
-  
+
   let trivial_well_formed = parser.is_well_formed_html("<!DOCTYPE html>\n<html><head></head><body></body></html>");
   assert!(trivial_well_formed);
 


### PR DESCRIPTION
The basic issue here was that we were casting to a pointer as a chain call on ```CString::new```, which in the latest nightly seems to result into null pointers by the time they are passed into libxml.

The refacotoring here fixes that, and we should be able to merge the PR that adds support for Rust stable next ( #2 ).

@jfschaefer let me know if you don't want to maintain the repo / are short on time, if you give me commit access I can push directly into the repo. Or we can move it to the KWARC org, up to you.